### PR TITLE
fix winner seat position number for single elimination 128.json

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/bracket_tree.gemspec
+++ b/bracket_tree.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec", '2.99'
   s.add_development_dependency "rake"
 end

--- a/lib/bracket_tree/templates/single_elimination/128.json
+++ b/lib/bracket_tree/templates/single_elimination/128.json
@@ -1019,7 +1019,7 @@
   ],
   "seats": [
     {
-      "position": 256
+      "position": 128
     },
     {
       "position": 64

--- a/spec/bracket_spec.rb
+++ b/spec/bracket_spec.rb
@@ -15,7 +15,7 @@ describe BracketTree::Bracket::Base do
       bracket.matches.should be_a Array
       bracket.matches.map(&:class).should == [BracketTree::Match, BracketTree::Match, BracketTree::Match]
     end
-    
+
     it 'should create an empty if matches are not passed' do
       bracket.matches.should be_a Array
       bracket.matches.should == []
@@ -193,6 +193,16 @@ describe BracketTree::Bracket::Base do
     [:winners, :losers, :round, :all, :first, :last, :seat].each do |m|
       it "should respond to #{m}" do
         bracket.should respond_to m
+      end
+    end
+  end
+
+  describe 'single elimination bracket' do
+    let(:klass) {BracketTree::Bracket::SingleElimination }
+
+    it 'builds brackets with expected depth' do
+      [[64, 7], [128,8]].each do |size, depth|
+        klass.by_size(size).depth.should == {:left => depth, :right => depth, :total => 7}
       end
     end
   end

--- a/spec/bracket_spec.rb
+++ b/spec/bracket_spec.rb
@@ -15,7 +15,7 @@ describe BracketTree::Bracket::Base do
       bracket.matches.should be_a Array
       bracket.matches.map(&:class).should == [BracketTree::Match, BracketTree::Match, BracketTree::Match]
     end
-    
+
     it 'should create an empty if matches are not passed' do
       bracket.matches.should be_a Array
       bracket.matches.should == []
@@ -193,6 +193,16 @@ describe BracketTree::Bracket::Base do
     [:winners, :losers, :round, :all, :first, :last, :seat].each do |m|
       it "should respond to #{m}" do
         bracket.should respond_to m
+      end
+    end
+  end
+
+  describe 'single elimination bracket' do
+    let(:klass) {BracketTree::Bracket::SingleElimination }
+
+    it 'builds brackets with expected depth' do
+      [[64, 7], [128,8]].each do |size, depth|
+        klass.by_size(size).depth.should == {:left => depth, :right => depth, :total => depth}
       end
     end
   end


### PR DESCRIPTION
I noticed that the single elimination 128 json final seat (the one for the winner) has a wrong position number.
The number was 256, but to comply with the Binary search tree rules, given its previous positions are 64 and 192, it must be 128. 

Regards

Andrea
